### PR TITLE
refresh/invalidate cache button

### DIFF
--- a/lib/Kalamar/Controller/Search.pm
+++ b/lib/Kalamar/Controller/Search.pm
@@ -35,6 +35,7 @@ sub query {
   $v->optional('collection', 'trim'); # Legacy
   $v->optional('cq', 'trim');         # New
   $v->optional('cutoff', 'trim')->in(qw/1 0 true false/);
+  $v->optional('refresh', 'trim')->in(qw/1 0 true false/);
   $v->optional('count', 'trim')->num(1, undef);
   $v->optional('p', 'trim')->num(1, undef); # Start page
   $v->optional('o', 'trim')->num(1, undef); # Offset
@@ -46,6 +47,9 @@ sub query {
   my $cutoff;
   if ($v->param('cutoff') && $v->param('cutoff') =~ /^1|true$/i) {
     $cutoff = 'true';
+  };
+  if ($v->param('refresh') && $v->param('refresh') =~ /^1|true$/i) {
+    $c->stash(refresh  => 'true');
   };
 
   # Deal with legacy collection

--- a/lib/Kalamar/Plugin/KalamarHelpers.pm
+++ b/lib/Kalamar/Plugin/KalamarHelpers.pm
@@ -123,6 +123,11 @@ sub register {
         );
       };
 
+      if ($c->stash('refresh') && $c->chi->is_valid($cache_str)) {
+        $c->app->log->debug("deleting " . $cache_str . " from cache");
+        $c->chi->remove($cache_str);
+      };
+
       # Get koral from cache
       my $koral = $c->chi->get($cache_str);
 

--- a/templates/partial/header.html.ep
+++ b/templates/partial/header.html.ep
@@ -23,6 +23,8 @@
       % param(cutoff => 1) unless param 'q';
       %= check_box cutoff => 1, id => 'q-cutoff-field', class => 'checkbox'
       <label for="q-cutoff-field" title="<%= loc('glimpse_desc') %>"><span id="glimpse"></span><%= loc('glimpse') %></label>
+      %= check_box refresh => 1, id => 'q-refresh-field', class => 'checkbox'
+      <label for="q-refresh-field" title="Refresh"><span id="refresh"></span>Refresh</label>
       <%= link_to 'doc_start', title => loc('tutorial'), class => "tutorial", id => "view-tutorial", tabindex => '-1', begin %><span><%= loc 'tutorial' %></span><% end %>
     </div>
     <div class="clear"></div>


### PR DESCRIPTION
Hello

we're currently spawning the korap/kalamar/kustvakt stack on demand for our internal needs, with the frontend and backend colocated on the same hardware, running as containers.

I'm still unsure how (timeout, empty response, 500 from backend) but in some cases, when a query is done before kustvakt has finished its startup and warmup, we have cases where a invalid response is cached and we can't query this particular term anymore without getting an empty result from cache

This PR is an attempt at adding a simple "refresh" checkbox to invalidate the cache on a query (which could probably also be useful if the backend index is updated without a frontend restart)

PS: I don't really understand the i18n mechanism used so feel free to fix this in the template file